### PR TITLE
Fix/beautify units

### DIFF
--- a/hnn_qt5.py
+++ b/hnn_qt5.py
@@ -1211,13 +1211,13 @@ class CellParamDialog (DictDialog):
       for k in d.keys():
         lk = k.split('_')
         if lk[-1] == 'L':
-          self.addtransvar(k,dtrans[lk[1]] + ' ' + r'length (micron)')
+          self.addtransvar(k,dtrans[lk[1]] + ' ' + r'length (µm)')
         elif lk[-1] == 'diam':
-          self.addtransvar(k,dtrans[lk[1]] + ' ' + r'diameter (micron)')
+          self.addtransvar(k,dtrans[lk[1]] + ' ' + r'diameter (µm)')
         elif lk[-1] == 'cm':
-          self.addtransvar(k,dtrans[lk[1]] + ' ' + r'capacitive density (F/cm2)')
+          self.addtransvar(k,dtrans[lk[1]] + ' ' + r'capacitive density (µF/cm²)')
         elif lk[-1] == 'Ra':
-          self.addtransvar(k,dtrans[lk[1]] + ' ' + r'resistivity (ohm-cm)')
+          self.addtransvar(k,dtrans[lk[1]] + ' ' + r'resistivity (Ω-cm)')
 
     for d in [self.dL2PyrSyn, self.dL5PyrSyn]:
       for k in d.keys():
@@ -1237,8 +1237,8 @@ class CellParamDialog (DictDialog):
             nv = dtrans[lk[1]] + ' ' + dtrans[lk[3]] + ' ' + ' channel density '
           else:
             nv = dtrans[lk[1]] + ' ' + dtrans[lk[2]] + ' ' + ' channel density '
-          if lk[3] == 'hh2': nv += '(S/cm2)'
-          else: nv += '(pS/micron2)'
+          if lk[3] in ['hh2','cat','ar']: nv += '(S/cm²)'
+          else: nv += '(pS/μm²)'
         elif lk[2].count('el') > 0: 
           nv = dtrans[lk[1]] + ' leak reversal (mV)'
         elif lk[2].count('taur') > 0:


### PR DESCRIPTION
There were a couple of unit discrepancies that I had fixed in the code in my own HNN but it might be good to update this in the GUI when we create the new version with parameter optimization. You can double check them: it seems the HCN and T-type calcium should be in S/cm² instead of pS/µm², and the capacitive density should be in µF/cm² instead of F/cm². I also think it looks better to have "µm²" instead of "micron2" and things like that.